### PR TITLE
Add getBuffer method to data object

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ var diff = resemble(file).compareTo(file2).ignoreColors().onComplete(function(da
 	{
 	  misMatchPercentage : 100, // %
 	  isSameDimensions: true, // or false
-	  getImageDataUrl: function(){}
+	  getImageDataUrl: function(){} // returns base64-encoded image
+	  pngStream: function(){} // returns stream with image data
+	  getBuffer: function(cb){} // calls callback with image buffer
 	}
 	*/
 });

--- a/resemble.js
+++ b/resemble.js
@@ -389,6 +389,10 @@ URL: https://github.com/Huddle/Resemble.js
 				context.putImageData(imgd, 0, 0);
 				return hiddenCanvas.pngStream();
 			};
+			data.getBuffer = function(cb) {
+				context.putImageData(imgd, 0, 0);
+				return hiddenCanvas.toBuffer(cb);
+			};
 			// END Modification
 			data.getImageDataUrl = function(text){
 				var barHeight = 0;


### PR DESCRIPTION
It's quite easy to create buffer from data URL or PNG stream, but it's even easier to simply request a buffer until Canvas API provides such method. So I've just proxied it in object returned to `onComplete` callback.